### PR TITLE
Simplify queries. to access systems and remove redundant queries.

### DIFF
--- a/components/query_handler/MSG_TYPES.py
+++ b/components/query_handler/MSG_TYPES.py
@@ -1,6 +1,0 @@
-MSG_TYPES = {
-    "GET_SYSTEMS": 1,
-    "GET_PROGRAMS": 2,
-    "GET_DEPLOYMENTS": 3,
-    "GET_TRACES": 4
-}

--- a/components/query_handler/README.md
+++ b/components/query_handler/README.md
@@ -27,59 +27,14 @@ The response to this query will be structured as follows:
         "systemId": 1234,
         "systemVersion": "0.0.2"
     },
-    "response":  <list of systems>
+    "response":  <list of systems with id, version, deployments and programs>
 }
-```
-### 2. Get Programs
-This query returns all the programs for a given system id and version.
-#### Query
-```
-{
-    "queryType": "GET_PROGRAMS",
-    "data": {
-        "systemId": 1234,
-        "systemVersion": "0.0.2"
-    }
-}
-```
-#### Response
-The response to this query will be structured as follows:
-```
-{
-    "queryType": "GET_PROGRAMS",
-    "data": {
-        "systemId": 1234,
-        "systemVersion": "0.0.2"
-    },
-    "response":  <list of programs>
-}
-```
-### 3. Get Deployments
-This query returns all the deployments for a given system id and version. 
-#### Query
-```
-{
-    "queryType": "GET_DEPLOYMENTS",
-    "data": {
-        "systemId": 1234,
-        "systemVersion": "0.0.2"
-    }
-}
-```
-#### Response
-The response to this query will be structured as follows:
-```
-{
-    "queryType": "GET_DEPLOYMENTS",
-    "data": {
-        "systemId": 1234,
-        "systemVersion": "0.0.2"
-    },
-    "response":  <list of deployment ids>
-}
-```
-### 4. Get Traces
-This query returns all the unique traces for a given system id and version.,
+
+### 2. Get Traces
+This query returns all the unique traces for a given system id and version, and deployment id.
+
+Note: A feature to filter by time range will be added in a coming PR.
+
 #### Query
 ```
 {

--- a/components/query_handler/queryFunctions.py
+++ b/components/query_handler/queryFunctions.py
@@ -16,78 +16,22 @@ def handleGetSystems(message):
         Get all systems.
     '''
     try:
-        message["response"] = reader.getSystems()
+        systems = reader.getSystems()
+        for system in systems:
+            system["deployments"] = reader.getDeployments(
+                systemId= system["system_id"],
+                systemVersion= system["version"]
+            )
+            system["programs"] = reader.getPrograms(
+                systemId= system["system_id"],
+                systemVersion= system["version"]
+            )
+        message["response"] = systems
     except Exception as e:
         message["error"] = True
         message["response"] = f"Database error: {e}"
 
     return message
-
-def handleGetPrograms(message):
-    '''
-        Get all programs given a system version and id.
-    '''
-    if ("data" not in message):
-        message["response"] = "Query does not contain the required data key."
-        message["error"] = True
-        return message
-    
-    data = message["data"]
-
-    if ("systemId" not in data):
-        message["response"] = "Query does not contain a system id."
-        message["error"] = True
-        return message
-
-    if ("systemVersion" not in data):
-        message["response"] = "Query does not contain a system version."
-        message["error"] = True
-        return message
-    
-    try:
-        message["response"] = reader.getPrograms(
-            systemId= message["data"]["systemId"],
-            systemVersion= message["data"]["systemVersion"]
-        )
-    except Exception as e:
-        message["error"] = True
-        message["response"] = f"Database error: {e}"
-
-    return message
-
-
-def handleGetDeployments(message):
-    '''
-        Get all deployments given a system id and version.
-    '''
-    if ("data" not in message):
-        message["response"] = "Query does not contain the required data key."
-        message["error"] = True
-        return message
-    
-    data = message["data"]
-
-    if ("systemId" not in data):
-        message["response"] = "Query does not contain a system id."
-        message["error"] = True
-        return message
-
-    if ("systemVersion" not in data):
-        message["response"] = "Query does not contain a system version."
-        message["error"] = True
-        return message
-
-    try:
-        message["response"] = reader.getDeployments(
-            systemId= message["data"]["systemId"],
-            systemVersion= message["data"]["systemVersion"]
-        )
-    except Exception as e:
-        message["error"] = True
-        message["response"] = f"Database error: {e}"
-
-    return message
-
 
 def handleGetTraces(message):
     '''
@@ -100,6 +44,7 @@ def handleGetTraces(message):
     
     data = message["data"]
 
+    # TODO: Add missing key response to a list and return all of them.
     if ("systemId" not in data):
         message["response"] = "Query does not contain a system id."
         message["error"] = True

--- a/components/query_handler/queryHandler.py
+++ b/components/query_handler/queryHandler.py
@@ -1,5 +1,4 @@
 import json
-from MSG_TYPES import MSG_TYPES
 from queryFunctions import *
 
 def handleQuery (message):
@@ -14,12 +13,6 @@ def handleQuery (message):
     
     if (message["queryType"] == "GET_SYSTEMS"):            
         response = handleGetSystems(message= message)
-        
-    elif (message["queryType"] == "GET_PROGRAMS"):            
-        response = handleGetPrograms(message= message)
-    
-    elif (message["queryType"] == "GET_DEPLOYMENTS"):
-        response = handleGetDeployments(message= message)
     
     elif (message["queryType"] == "GET_TRACES"):
         response = handleGetTraces(message= message)


### PR DESCRIPTION
This PR updates the query handler so that all the system information can be loaded from a single query. The reason for this change is it simplifies the implementation here and in ASV.  Many existing query types were removed because they are not needed anymore. An updated list of queries is provided below.

## Queries
The following are a list of queries that the query server accepts.

### 1. Get Systems
This query returns all the systems in the database. 

#### Query
```
{
    "queryType":  "GET_SYSTEMS"
}
```
#### Response
The response to this query will be structured as follows:
```
{
    "queryType": "GET_SYSTEMS",
    "data": {
        "systemId": 1234,
        "systemVersion": "0.0.2"
    },
    "response":  <list of systems with id, version, deployments and programs>
}
```
### 2. Get Traces
This query returns all the unique traces for a given system id and version, and deployment id.

Note: A feature to filter by time range will be added in a coming PR.

#### Query
```
{
    "queryType": "GET_TRACES",
    "data": {
        "systemId": 1234,
        "systemVersion": "0.0.2",
        "deploymentId": "ff842dc3-92a4-4d0a-9a67-d27444f3f98f"
    }
}
```
#### Response
The response to this query will be structured as follows:
```
{
    "queryType": "GET_TRACES",
    "data": {
        "systemId": 1234,
        "systemVersion": "0.0.2",
        "deploymentId": "ff842dc3-92a4-4d0a-9a67-d27444f3f98f"
    },
    "response":  <list of traces>
}
```
## Validation Performed

Connected to websocket server using postman and performed the following validation:
- Sent message to get systems and verified that the response matched the description above. 
- Sent message to get traces and verified that the response matched the description above.