### PR TITLE
Add database as a service using docker.

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -19,9 +19,11 @@ tasks:
 
   clean-containers:
     cmds:
+      - task: stop
       - python3 {{.ROOT_DIR}}/scripts/clean_containers.py
 
   clean-images:
     cmds:
+      - task: stop
       - python3 {{.ROOT_DIR}}/scripts/clean_containers.py
       - python3 {{.ROOT_DIR}}/scripts/clean_images.py

--- a/scripts/clean_containers.py
+++ b/scripts/clean_containers.py
@@ -3,7 +3,10 @@ from utils import isDockerInstalled, doesContainerExist
 import subprocess
 import sys
 
-def clearAsvContainer():
+def deleteAsvContainer():
+    '''
+        Deletes the ASV Container.
+    '''
     try:
         isContainerLoaded = doesContainerExist(ASV_DEF["CONTAINER_NAME"])
 
@@ -25,7 +28,10 @@ def clearAsvContainer():
         print(f"Error when removing ASV container: {e}")
         return False
     
-def clearDlvContainer():    
+def deleteDlvContainer():    
+    '''
+        Deletes the DLV container.
+    '''
     try:
         isContainerLoaded = doesContainerExist(DLV_DEF["CONTAINER_NAME"])
 
@@ -47,7 +53,10 @@ def clearDlvContainer():
         print(f"Error when removing DLV container: {e}")
         return False
     
-def clearDbContainers():    
+def deleteDbContainers():  
+    '''
+        Delete the DB container.
+    '''  
     try:
         isContainerLoaded = doesContainerExist(DB_DEF["CONTAINER_NAME"])
 
@@ -73,13 +82,13 @@ def main(argv):
     if (not isDockerInstalled()):
         return -1
     
-    if (not clearAsvContainer()):
+    if (not deleteAsvContainer()):
         return -1
     
-    if (not clearDlvContainer()):
+    if (not deleteDlvContainer()):
         return -1
     
-    if (not clearDbContainers()):
+    if (not deleteDbContainers()):
         return -1
     
     return 0

--- a/scripts/clean_containers.py
+++ b/scripts/clean_containers.py
@@ -1,4 +1,4 @@
-from constants import ASV_DEF, DLV_DEF
+from constants import ASV_DEF, DLV_DEF, DB_DEF
 from utils import isDockerInstalled, doesContainerExist
 import subprocess
 import sys
@@ -46,6 +46,28 @@ def clearDlvContainer():
     except Exception as e:
         print(f"Error when removing DLV container: {e}")
         return False
+    
+def clearDbContainers():    
+    try:
+        isContainerLoaded = doesContainerExist(DB_DEF["CONTAINER_NAME"])
+
+        if not isContainerLoaded:
+            print("DB Container does not exist. No need to clear it.")
+            return True
+
+        cmd = ["docker", "rm", DB_DEF["CONTAINER_NAME"]]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            print(f'Failed to remove container: {DB_DEF["CONTAINER_NAME"]}')
+            return False
+        
+        print("Removed DB Container.")
+
+        return True    
+    except Exception as e:
+        print(f"Error when removing DB container: {e}")
+        return False
 
 def main(argv):
     if (not isDockerInstalled()):
@@ -55,6 +77,9 @@ def main(argv):
         return -1
     
     if (not clearDlvContainer()):
+        return -1
+    
+    if (not clearDbContainers()):
         return -1
     
     return 0

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -16,3 +16,11 @@ DLV_DEF = {
     "DATA_DIR": "data/dlv",
 }
 
+DB_DEF = {
+    "CONTAINER_NAME": "mariadb-container",
+    "PORT": 3306,
+    "DATABASE_NAME": "asp-database",
+    "DATABASE_PASSWORD": "random-password",
+    "DATA_DIR": "data/mariadb",
+}
+

--- a/scripts/stop_components.py
+++ b/scripts/stop_components.py
@@ -1,6 +1,6 @@
 import subprocess
 import os, sys
-from constants import ASV_DEF, DLV_DEF
+from constants import ASV_DEF, DLV_DEF, DB_DEF
 from utils import isDockerInstalled, doesContainerExist
 
 def stopASV():
@@ -55,6 +55,32 @@ def stopDLV():
     print("Stopped DLV service.")
     return True
 
+def stopDB():
+    '''
+        Stop the DB container.
+    '''
+    print("Stopping DB...")
+    
+    isContainerLoaded = doesContainerExist(DB_DEF["CONTAINER_NAME"])
+
+    if not isContainerLoaded:
+        print("DB Container does not exist. No need to stop it.")
+        return True
+
+    cmd = ["docker", "stop",  DB_DEF["CONTAINER_NAME"]]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)    
+        if result.returncode != 0:
+            print(f"Failed to stop DB container: {result.stderr}")
+            return False   
+    except Exception as e:
+        print(f"Error stopping DB container: {str(e)}")
+        return False
+    
+    print("Stopped DB service.")
+    return True
+
 def main(argv):
     if (not isDockerInstalled()):
         return -1
@@ -63,6 +89,9 @@ def main(argv):
         return -1
     
     if (not stopDLV()):
+        return -1
+    
+    if (not stopDB()):
         return -1
     
     return 0

--- a/scripts/stop_components.py
+++ b/scripts/stop_components.py
@@ -7,7 +7,7 @@ def stopASV():
     '''
         Stop the ASV container.
     '''
-    print("Stopping ASV...")
+    print("\nStopping ASV...")
     
     isContainerLoaded = doesContainerExist(ASV_DEF["CONTAINER_NAME"])
 
@@ -33,7 +33,7 @@ def stopDLV():
     '''
         Stop the DLV container.
     '''
-    print("Stopping DLV...")
+    print("\nStopping DLV...")
     
     isContainerLoaded = doesContainerExist(DLV_DEF["CONTAINER_NAME"])
 
@@ -59,7 +59,7 @@ def stopDB():
     '''
         Stop the DB container.
     '''
-    print("Stopping DB...")
+    print("\nStopping DB...")
     
     isContainerLoaded = doesContainerExist(DB_DEF["CONTAINER_NAME"])
 


### PR DESCRIPTION
This PR starts mariadb inside a docker container along with the other components. 

This makes the following changes:
- It defines the database container and connection configuration
- It adds the database to the start and stop scripts
- It adds the database containers to clean containers script

## Validation Performed

- Started the database container by running `task start`
- Connected to database using DBeaver. 
- Used credentials:
    - Database Name: asp-database
    - Port: 3306
    - Password: random-password
- Created table and inserted item
- Ran `task stop` to stop all containers
- Ran `task start` to start containers
- Connected to database and verified that data was preserved
- Ran task clean-images to fully reset docker images and containers
- Ran task start to start the containers
- Connected to database and verified that the data is present 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for managing a MariaDB Docker container, including starting, stopping, and cleaning up the database container as part of component lifecycle tasks.

- **Chores**
  - Updated task automation to ensure all components are stopped before cleaning containers or images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->