### PR TITLE
Rename all containers and images so that they have an "asp" prefix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 asp.db
 ioEvents.db
 data
+system_logs

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,6 +1,6 @@
 ASV_DEF = {
     "CONTAINER_NAME": "asp-asv-container",
-    "IMAGE_NAME": "asv-image",
+    "IMAGE_NAME": "asp-asv-image",
     "IMAGE_PATH": "docker-images/asv/Dockerfile",
     "COMPONENT_PATH": "components_new/asv",
     "PORT": 3012,
@@ -9,7 +9,7 @@ ASV_DEF = {
 
 DLV_DEF = {
     "CONTAINER_NAME": "asp-dlv-container",
-    "IMAGE_NAME": "dlv-image",
+    "IMAGE_NAME": "asp-dlv-image",
     "IMAGE_PATH": "docker-images/dlv/Dockerfile",
     "COMPONENT_PATH": "components_new/dlv",
     "PORT": 3011,
@@ -26,7 +26,7 @@ DB_DEF = {
 
 ASP_DEF = {
     "CONTAINER_NAME": "asp-container",
-    "IMAGE_NAME": "asp-image",
+    "IMAGE_NAME": "asp-asp-image",
     "IMAGE_PATH": "docker-images/asp/Dockerfile",
     "COMPONENT_PATH": "components_new/asp",
     "DATA_DIR": "data/asp",

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,5 +1,5 @@
 ASV_DEF = {
-    "CONTAINER_NAME": "asv-container",
+    "CONTAINER_NAME": "asp-asv-container",
     "IMAGE_NAME": "asv-image",
     "IMAGE_PATH": "docker-images/asv/Dockerfile",
     "COMPONENT_PATH": "components_new/asv",
@@ -8,7 +8,7 @@ ASV_DEF = {
 }
 
 DLV_DEF = {
-    "CONTAINER_NAME": "dlv-container",
+    "CONTAINER_NAME": "asp-dlv-container",
     "IMAGE_NAME": "dlv-image",
     "IMAGE_PATH": "docker-images/dlv/Dockerfile",
     "COMPONENT_PATH": "components_new/dlv",
@@ -17,7 +17,7 @@ DLV_DEF = {
 }
 
 DB_DEF = {
-    "CONTAINER_NAME": "mariadb-container",
+    "CONTAINER_NAME": "asp-mariadb-container",
     "PORT": 3306,
     "DATABASE_NAME": "aspDatabase",
     "DATABASE_PASSWORD": "random-password",


### PR DESCRIPTION
This PR renames the docker constants (container name, image name etc...) so that they have an asp prefix.

Updated names:

|                | ASP           | DB                    | DLV               | ASV               |
|----------------|---------------|-----------------------|-------------------|-------------------|
| CONTAINER_NAME | asp-container | asp-mariadb-container | asp-dlv-container | asp-asv-container |
| IMAGE_NAME     | asp-image     | mariadb:latest        | asp-dlv-image     | asv-image         |