### PR TITLE
Update name of container used to establish database connection.

### DIFF
--- a/components_new/asp/db.py
+++ b/components_new/asp/db.py
@@ -7,7 +7,7 @@ def get_connection():
     isDocker = os.environ.get('IS_RUNNING_IN_DOCKER', False)
 
     if isDocker:
-        host = "mariadb-container"
+        host = "asp-mariadb-container"
     else:
         host = "localhost"
 

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -26,7 +26,7 @@ DB_DEF = {
 
 ASP_DEF = {
     "CONTAINER_NAME": "asp-container",
-    "IMAGE_NAME": "asp-asp-image",
+    "IMAGE_NAME": "asp-image",
     "IMAGE_PATH": "docker-images/asp/Dockerfile",
     "COMPONENT_PATH": "components_new/asp",
     "DATA_DIR": "data/asp",


### PR DESCRIPTION
This PR fixes a bug introduced in PR #37. The updated database container name was not used to connect to the database from ASP.

This PR also fixes another issue where the asp container contained multiple prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated database connection settings for Docker environments.
  - Modified the image name used in configuration constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->