### PR TITLE
Add script to install dependencies on machines running ubuntu.

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This script installs the dependencies needed to run the application.
+
 # Exit on any error
 set -e
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -18,7 +18,6 @@ DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   python3 \
   python3-pip \
   python3-venv \
-  python3-mysql.connector \
   software-properties-common \
   unzip
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+# Update and install libraries
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  ca-certificates \
+  checkinstall \
+  curl \
+  git \
+  python3 \
+  python3-pip \
+  python3-venv \
+  python3-mysql.connector \
+  software-properties-common \
+  unzip
+
+
+# Install task if it isn't installed.
+if command -v task &> /dev/null; then
+    echo "Task is already installed: $(task --version)"
+else
+    echo "Task was not found, installing..."
+    task_pkg_arch=$(dpkg --print-architecture)
+    task_pkg_path="$(mktemp -t --suffix ".deb" task-pkg.XXXXXXXXXX)"
+    curl \
+        --fail \
+        --location \
+        --output "$task_pkg_path" \
+        --show-error \
+        "https://github.com/go-task/task/releases/download/v3.42.1/task_linux_${task_pkg_arch}.deb"
+    dpkg --install "$task_pkg_path"
+    rm "$task_pkg_path"
+fi

--- a/scripts/start_components.py
+++ b/scripts/start_components.py
@@ -320,7 +320,7 @@ def main(argv):
     if not startDatabase():
         return -1
     
-    print("Waiting for database to start")
+    print("Waiting for database to start...")
     time.sleep(10)
     
     if not startASP():

--- a/scripts/start_components.py
+++ b/scripts/start_components.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import mysql.connector
 import subprocess
 from utils import doesContainerExist, buildImage, isDockerInstalled
 from constants import ASV_DEF, DLV_DEF, DB_DEF, ASP_DEF, NET_DEF, QUERY_HANDLER_DEF
@@ -304,31 +303,6 @@ def createNetwork():
     except Exception as e:
         print(f"Error when creating network named: {e}")
         return False
-    
-
-def checkDatabaseConnection():
-
-    try:
-        print("Attempting database connection...")
-        conn = mysql.connector.connect(
-            host= "localhost",
-            user= "root",
-            password= DB_DEF["DATABASE_PASSWORD"],
-            database= DB_DEF["DATABASE_NAME"],
-            port= str(DB_DEF["PORT"]),
-            autocommit=True 
-        )
-        if conn.is_connected():
-            cursor = conn.cursor()
-            cursor.execute("SELECT 1;")
-            cursor.fetchone()
-            conn.close()
-            print("Database is live.")
-            return True
-        
-    except Exception:
-        print("Database is not accessible yet.")
-        return False
 
 def main(argv):
     if not isDockerInstalled():
@@ -346,16 +320,8 @@ def main(argv):
     if not startDatabase():
         return -1
     
-    # Wait for database to start
-    count = 0
-    print("Checking database connection.")
-    while(not checkDatabaseConnection()):
-        if (count == 10):
-            print("Failed to connect to database. Exiting.")
-            return -1
-        else:
-            count += 1
-            time.sleep(3)
+    print("Waiting for database to start")
+    time.sleep(10)
     
     if not startASP():
         return -1


### PR DESCRIPTION
This PR adds a script to install the dependencies needed to run ASP on a machine running ubuntu. 

Docker is a requirement that has to be installed by the user and it should be usable without needing sudo access.

Note: Currently, there is no process to build the system. When that is implemented, ASV and DLV will be built and deployed to a container. It isn't really an issue now because ASP is a simple application but that will change over time, so I will improve this soon.

## Validation Performed

- Tested the script on a clean ec2 ubuntu instance
- Tested on WSL ubuntu instance
- Tested on a ubuntu-jammy container in docker

In all three cases, verified that the installed libraries were accessible. 

Note: For python version 3.12, you need a version of mysql.connector that is >=8.2.0. This is an issue I ran into when running on an ec2 ubuntu instance. While I finish implementing this workflow, I decided to remove the database startup check from the start components script to simplify the dependencies. I will implement the database status check in a different way in a coming PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an automated script to install all required system dependencies and the Task utility for streamlined setup.
- **Bug Fixes**
  - Simplified database startup by replacing active connectivity checks with a fixed delay for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->